### PR TITLE
Add unmock-jest-runner

### DIFF
--- a/introduction/step3.md
+++ b/introduction/step3.md
@@ -8,7 +8,9 @@ In order to define multiple responses, continue adding to `unmock.nock`.
 
 ## Fuzz testing
 
-Fuzzy wuzzy wuz a bear, and fuzz testing is when you do the same thing multiple times with slight variations. Unmock's `runner` will take care of that for you - it runs your test several times with slightly different results depending on how you initialize the state.  Which leads us to...
+Fuzzy wuzzy wuz a bear, and fuzz testing is when you do the same thing multiple times with slight variations. Unmock's `runner` will take care of that for you - it runs your test several times (the default is 20) with slightly different results. For this tutorial, we will be importing a Jest configuration of the `runner` from a package called `unmock-jest-runner`.
+
+The results you get for your tests depend on how you initialize the state.  Which leads us to...
 
 ## Initializing mocks
 


### PR DESCRIPTION
We're going to replace instances of imported unmock runner with new [`unmock-jest-runner`](https://www.npmjs.com/package/unmock-jest-runner) package in the Katacoda tutorial code - so we needed to update that here as well. 

Should be merged at the same time as https://github.com/unmock/unmock-katacoda-tutorial/pull/7

Related to https://github.com/Meeshkan/unmock-js/issues/299